### PR TITLE
Add HACS testing

### DIFF
--- a/.github/workflows/hacs.yml
+++ b/.github/workflows/hacs.yml
@@ -1,0 +1,18 @@
+name: HACS Action
+
+on:
+  push:
+  pull_request:
+  schedule:
+    - cron: "0 0 * * *"
+
+jobs:
+  hacs:
+    name: HACS Action
+    runs-on: "ubuntu-latest"
+    steps:
+      - uses: "actions/checkout@v2"
+      - name: HACS Action
+        uses: "hacs/action@main"
+        with:
+          category: "integration"

--- a/.github/workflows/hacs.yml
+++ b/.github/workflows/hacs.yml
@@ -16,3 +16,4 @@ jobs:
         uses: "hacs/action@main"
         with:
           category: "integration"
+          ignore: "brands"

--- a/.github/workflows/hacs.yml
+++ b/.github/workflows/hacs.yml
@@ -16,4 +16,4 @@ jobs:
         uses: "hacs/action@main"
         with:
           category: "integration"
-          ignore: "brands"
+          ignore: "brands wheels"

--- a/.github/workflows/hacs.yml
+++ b/.github/workflows/hacs.yml
@@ -16,4 +16,4 @@ jobs:
         uses: "hacs/action@main"
         with:
           category: "integration"
-          ignore: "brands wheels"
+          ignore: "brands requirements wheels"

--- a/custom_components/discovergy/manifest.json
+++ b/custom_components/discovergy/manifest.json
@@ -10,6 +10,7 @@
     "@schlac",
     "@jpbede"
   ],
+  "issue_tracker": "https://github.com/schlac/hacs-integration-discovergy/issues",
   "iot_class": "cloud_polling",
   "version": "0.0.1"
 }


### PR DESCRIPTION
Brands check can be re-enabled once https://github.com/home-assistant/brands/pull/2740 is merged.